### PR TITLE
[Feat] Add entities to MySQL DataSource configuration

### DIFF
--- a/src/config/mysql.config.ts
+++ b/src/config/mysql.config.ts
@@ -1,5 +1,9 @@
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
+import {Tag} from "../entity/tag.entity";
+import {Term} from "../entity/term.entity";
+import {TermVersion} from "../entity/termVersion.entity";
+import {Banner} from "../entity/banner.entity";
 
 const HOST = process.env.DB_HOST || 'localhost';
 const PORT = Number(process.env.DB_PORT) || 3306;
@@ -16,7 +20,7 @@ const AppDataSource = new DataSource({
     database: DB_NAME,
     synchronize: false,
     logging: true,
-    entities: [],
+    entities: [ Tag, Term, TermVersion, Banner ],
     migrations: [],
     subscribers: [],
 });


### PR DESCRIPTION
Included Tag, Term, TermVersion, and Banner entities in the TypeORM configuration to enable their management in the database. This ensures proper mapping and functionality for these models.