### PR TITLE
Log tag name before and after setting it in registerTag

### DIFF
--- a/src/service/tag.service.ts
+++ b/src/service/tag.service.ts
@@ -4,8 +4,10 @@ import {TagDto, toTagDto} from "../dto/tag.dto";
 
 export const registerTag = async (tagName: string)=> {
     try {
+        console.log("before: " + tagName);
         const tag = new Tag();
         tag.setName(tagName);
+        console.log("after: " + tag.name);
         return await saveTag(tag);
     } catch (error) {
         throw error;


### PR DESCRIPTION
Added console logs to output the tag name before and after calling the `setName` method. This change aids in debugging by providing visibility into the tag's state during the registration process.