### PR TITLE
[Fix] Remove unused schema definition comments in get.route.ts

### DIFF
--- a/src/route/get.route.ts
+++ b/src/route/get.route.ts
@@ -17,8 +17,6 @@ import {GetBannerDto} from "../dto/banner.dto";
  *         name:
  *           type: string
  *           example: "Action"
- * components:
- *   schemas:
  *     GetBannerDto:
  *       type: object
  *       properties:


### PR DESCRIPTION
Eliminated redundant components schema comments to improve code clarity and maintainability. This change ensures that unused or irrelevant code fragments do not clutter the file.