### PR TITLE
[Fix] Fix banner image upload handling for single file consistency

### DIFF
--- a/src/route/banner.route.ts
+++ b/src/route/banner.route.ts
@@ -68,11 +68,12 @@ router.post('/create', upload.fields([
     try {
         const createBannerDto: CreateBannerDto = JSON.parse(req.body.json) as CreateBannerDto;
 
-        const imageFiles = (req.files as any)?.['imageUrl'] || [0];
+        const imageFile = (req.files as any)?.['imageUrl']?.[0];
+        if (!imageFile) throw new Error("No banner image file uploaded");
 
         createBannerDto.imageUrl = {
-            path: imageFiles.path,
-            mimetype: imageFiles.mimetype
+            path: imageFile.path,
+            mimetype: imageFile.mimetype
         };
 
         createBannerDto.adminId = req.userId as number;


### PR DESCRIPTION
Previously, the code incorrectly assumed an array for image upload, which caused errors. This update ensures the system correctly processes a single uploaded image file and throws an error when no file is provided.