### PR TITLE
[Refactor] Refactor banner image handling to unify URL and key usage

### DIFF
--- a/src/dto/banner.dto.ts
+++ b/src/dto/banner.dto.ts
@@ -35,11 +35,11 @@ export function toBannerEntity(dto: CreateBannerDto): Banner {
   return banner;
 }
 
-export function toBannerDto(banner: Banner, imageUrl: string): GetBannerDto {
+export function toBannerDto(banner: Banner): GetBannerDto {
   return {
     id: banner.id,
     title: banner.title,
-    imageUrl: imageUrl,
+    imageUrl: banner.imageUrl,
     linkUrl: banner.linkUrl,
   }
 }

--- a/src/entity/banner.entity.ts
+++ b/src/entity/banner.entity.ts
@@ -14,6 +14,9 @@ export class Banner {
     @Column({ type: "varchar", length: 255, nullable: false, name: "image_url" })
     imageUrl: string;
 
+    @Column({ type: "varchar", length: 255, nullable: false })
+    key: string;
+
     @Column({ type: "varchar", length: 255, nullable: true, name: "link_url" })
     linkUrl: string;
 

--- a/src/service/s3.service.ts
+++ b/src/service/s3.service.ts
@@ -7,7 +7,7 @@ import {getSignedUrl} from "@aws-sdk/s3-request-presigner";
 export const uploadBannerImageToS3 = async (
     image: { path: string; mimetype: string },
     bannerId: number
-): Promise<string> => {
+): Promise<{ url:string, key:string }> => {
     const buffer = await readFile(image.path);
     const key = `banners/${bannerId}/${uuidv4()}${image.path.substring(image.path.lastIndexOf('.'))}`;
 
@@ -23,9 +23,11 @@ export const uploadBannerImageToS3 = async (
         throw new Error("Failed to upload banner image to S3");
     }
 
-    return key;
-};
+    const url = `https://${process.env.AWS_S3_BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
 
+    return { url, key };
+};
+/*
 export async function getBannerPresignedUrl(key: string): Promise<string> {
     const expiresInSec = 60;
 
@@ -41,3 +43,4 @@ export async function getBannerPresignedUrl(key: string): Promise<string> {
         throw new Error("Failed to generate presigned banner URL");
     }
 }
+*/


### PR DESCRIPTION
Removed dependency on presigned URLs by embedding full S3 URLs directly into banners. Updated S3 service to return both URL and key, streamlined DTO conversions, and added a new "key" property to the Banner entity.