### PR TITLE
[Feat] Add CacheControl and ACL to S3 upload parameters

### DIFF
--- a/src/service/s3.service.ts
+++ b/src/service/s3.service.ts
@@ -16,7 +16,9 @@ export const uploadBannerImageToS3 = async (
             Bucket: process.env.AWS_S3_BUCKET,
             Key: key,
             Body: buffer,
-            ContentType: image.mimetype
+            ContentType: image.mimetype,
+            CacheControl: "public, max-age=604800",
+            ACL: "public-read"
         }));
     } catch (error) {
         console.error("S3 upload error:", error);


### PR DESCRIPTION
Enhanced the S3 upload function by setting CacheControl to "public, max-age=604800" for caching and improved performance. Also added ACL as "public-read" to ensure uploaded files are publicly accessible.