### PR TITLE
refactor: Update banner image resize dimensions in route

### DIFF
--- a/src/route/banner.route.ts
+++ b/src/route/banner.route.ts
@@ -75,7 +75,7 @@ router.post('/create', upload.fields([
 
         const webpPath = imageFile.path + ".webp";
         await sharp(imageFile.path)
-          .resize(1440, 400, { fit: "cover" })
+          .resize(1229, 819, { fit: "cover" })
           .webp({ quality: 80 })
           .toFile(webpPath);
         await fs.unlink(imageFile.path);


### PR DESCRIPTION
Adjusted the image resizing parameters to 1229x819 for better alignment with new design requirements. This ensures consistent rendering and improved visual appearance across supported devices.