### PR TITLE
fix: Update image resizing to use "inside" fit mode

### DIFF
--- a/src/route/banner.route.ts
+++ b/src/route/banner.route.ts
@@ -75,7 +75,7 @@ router.post('/create', upload.fields([
 
         const webpPath = imageFile.path + ".webp";
         await sharp(imageFile.path)
-          .resize(1229, 819, { fit: "cover" })
+          .resize(1229, 819, { fit: "inside" })
           .webp({ quality: 80 })
           .toFile(webpPath);
         await fs.unlink(imageFile.path);


### PR DESCRIPTION
Changed the Sharp resize mode from "cover" to "inside" for banner images. This ensures the aspect ratio is preserved, preventing potential cropping issues and improving visual consistency.