### PR TITLE
[Feat] Add choseong support for tags using es-hangul library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@grpc/proto-loader": "^0.7.13",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
+        "es-hangul": "^2.3.3",
         "express": "^5.1.0",
         "ioredis": "^5.6.0",
         "multer": "^1.4.5-lts.2",
@@ -3296,6 +3297,17 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-hangul": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/es-hangul/-/es-hangul-2.3.3.tgz",
+      "integrity": "sha512-2pykqtOg7U9hAio5E4IJzVNCkx+iEs5fkYJr+8rcUxQbPtsA0MDpsTvavIMgnDeepGrEzI6I1yIWNcmYFdyTsA==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@grpc/proto-loader": "^0.7.13",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
+    "es-hangul": "^2.3.3",
     "express": "^5.1.0",
     "ioredis": "^5.6.0",
     "multer": "^1.4.5-lts.2",

--- a/src/dto/tag.dto.ts
+++ b/src/dto/tag.dto.ts
@@ -4,6 +4,7 @@ export interface TagDto {
     id?: number;
     name: string;
     nameKo?: string;
+    nameChoseong?: string;
 }
 
 export function toTagDto(tag: Tag): TagDto {

--- a/src/entity/tag.entity.ts
+++ b/src/entity/tag.entity.ts
@@ -11,11 +11,18 @@ export class Tag {
     @Column({ name: 'name_ko', type: 'varchar', length: 255, nullable: true })
     nameKo: string;
 
+    @Column({ name: 'name_choseong', type: 'varchar', length: 255, nullable: true })
+    nameChoseong: string;
+
     setName(name: string) {
         this.name = name;
     }
 
     setNameKo(nameKo: string) {
         this.nameKo = nameKo;
+    }
+
+    setNameChoseong(nameChoseong: string) {
+        this.nameChoseong = nameChoseong;
     }
 }

--- a/src/repository/tag.repository.ts
+++ b/src/repository/tag.repository.ts
@@ -16,7 +16,7 @@ export const saveTag = async (tag: Tag) => {
 
 export const updateTag = async (tag: TagDto) => {
     try {
-        return await tagRepo.update({ id: tag.id }, { name: tag.name, nameKo: tag.nameKo });
+        return await tagRepo.update({ id: tag.id }, { name: tag.name, nameKo: tag.nameKo, nameChoseong: tag.nameChoseong });
     } catch (error) {
         console.error('Failed to update tag:', error);
         throw new Error('Failed to update tag in database');

--- a/src/service/tag.service.ts
+++ b/src/service/tag.service.ts
@@ -1,15 +1,19 @@
 import {deleteTag, getTag, saveTag, updateTag} from "../repository/tag.repository";
 import {Tag} from "../entity/tag.entity";
 import {TagDto, toTagDto} from "../dto/tag.dto";
+import {getChoseong} from "es-hangul";
 
 export const registerTag = async (tagDto: TagDto)=> {
+    const nameChoseong = getChoseong(tagDto.nameKo as string);
     const tag = new Tag();
     tag.setName(tagDto.name);
     tag.setNameKo(tagDto.nameKo as string);
+    tag.setNameChoseong(nameChoseong);
     return await saveTag(tag);
 };
 
 export const editTag = async (tagDto: TagDto) => {
+    tagDto.nameChoseong = getChoseong(tagDto.nameKo as string);
     await updateTag(tagDto);
 };
 


### PR DESCRIPTION
Introduced a new `nameChoseong` field to `Tag` entity and DTO to store the choseong (initial Korean consonants) derived from `nameKo`. Integrated the `es-hangul` library to calculate and set choseong values during tag registration and updates. Updated database schema, repository, and service logic accordingly.