### PR TITLE
feat: Update Swagger server URL to new API server address

### DIFF
--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -19,7 +19,7 @@ const options = {
     },
     servers: [
       {
-        url: 'http://3.37.46.45:30354',
+        url: 'http://16.184.9.194:30354',
         description: '플랫폼 관리자 API 서버'
       }
     ],


### PR DESCRIPTION
Changed the server URL in the Swagger configuration file to point to the updated API server. This ensures the documentation reflects the correct endpoint for the platform administrator API.